### PR TITLE
update contract unit tests to work with libtester from leap's main branch

### DIFF
--- a/contract/tests/mapping_tests.cpp
+++ b/contract/tests/mapping_tests.cpp
@@ -98,7 +98,7 @@ try {
    BOOST_REQUIRE(produce_blocks_until_timestamp_satisfied(timestamp_at_second_boundary));
 
    init();
-   time_point_sec expected_genesis_time = control->pending_block_time(); // Rounds down to nearest second.
+   time_point_sec expected_genesis_time = time_point_sec(control->pending_block_time()); // Rounds down to nearest second.
 
    time_point_sec actual_genesis_time = get_genesis_time();
    ilog("Genesis time: ${time}", ("time", actual_genesis_time));
@@ -115,7 +115,7 @@ try {
    BOOST_REQUIRE(produce_blocks_until_timestamp_satisfied(timestamp_not_at_second_boundary));
 
    init();
-   time_point_sec expected_genesis_time = control->pending_block_time(); // Rounds down to nearest second.
+   time_point_sec expected_genesis_time = time_point_sec(control->pending_block_time()); // Rounds down to nearest second.
 
    time_point_sec actual_genesis_time = get_genesis_time();
    ilog("Genesis time: ${time}", ("time", actual_genesis_time));


### PR DESCRIPTION
need explicit `time_point_sec` cast on leap's libtester main branch since AntelopeIO/leap#1125

I believe this will work on 3.x too, so targeting it straight to main instead of chaining on #456