### PR TITLE
tweak for building EVM contract with CDT 4.0

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           owner: AntelopeIO
           repo: cdt
-          target: 'v3.1.0'
-          prereleases: false
+          target: 'v4.0'
+          prereleases: true
           file: 'cdt_.*amd64.deb'
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/contract/include/evm_runtime/evm_contract.hpp
+++ b/contract/include/evm_runtime/evm_contract.hpp
@@ -145,13 +145,3 @@ private:
 
 } // namespace evm_runtime
 
-namespace std {
-template <typename DataStream>
-DataStream& operator<<(DataStream& ds, const std::basic_string<uint8_t>& bs)
-{
-   ds << (unsigned_int)bs.size();
-   if (bs.size())
-      ds.write((const char*)bs.data(), bs.size());
-   return ds;
-}
-} // namespace std


### PR DESCRIPTION
Remove some code required for building the contract with CDT 3.1 that breaks the contract with CDT 4.0. Merging this should only be done when comfortable only building the contract with CDT 4.0.x