### PR TITLE
CDT 4.0.0 basic_string issue, temporary fix.

### DIFF
--- a/contract/include/evm_runtime/evm_contract.hpp
+++ b/contract/include/evm_runtime/evm_contract.hpp
@@ -148,7 +148,6 @@ private:
 
 } // namespace evm_runtime
 
-namespace std {
 template <typename DataStream>
 DataStream& operator<<(DataStream& ds, const std::basic_string<uint8_t>& bs)
 {
@@ -157,4 +156,3 @@ DataStream& operator<<(DataStream& ds, const std::basic_string<uint8_t>& bs)
       ds.write((const char*)bs.data(), bs.size());
    return ds;
 }
-} // namespace std


### PR DESCRIPTION
So, I had to remove the `std` namespace on this, not sure why it was `std`. But, just allow ADL to take care of it for now.

I have a PR up in CDT to resolve this (so you can remove the entire overload) and we will try to get a patch release out soon.