### PR TITLE
[0.5 -> main] EstimateGasOracle: fix estimate_gas; Return better result when accessed by GET

### DIFF
--- a/peripherals/proxy/nginx.conf
+++ b/peripherals/proxy/nginx.conf
@@ -66,7 +66,8 @@ http {
           add_header 'Access-Control-Allow-Credentials' 'true';
           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
           add_header 'Access-Control-Allow-Headers' '*';
-          return 204;
+          add_header 'Content-Type' 'text/html';
+          return 200 '<!DOCTYPE html>This is an API endpoint that only accepts JSON-RPC requests. <br> Please visit <a href = "https://docs.eosnetwork.com/docs/latest/eos-evm/">https://docs.eosnetwork.com/docs/latest/eos-evm/</a> for information about EOS EVM. \n';
       }
       
       resolver 127.0.0.11;

--- a/silkrpc/core/estimate_gas_oracle.hpp
+++ b/silkrpc/core/estimate_gas_oracle.hpp
@@ -88,7 +88,7 @@ public:
     boost::asio::awaitable<intx::uint256> estimate_gas(const Call& call, uint64_t block_number);
 
 private:
-    boost::asio::awaitable<bool> try_execution(const silkworm::Transaction& transaction);
+    boost::asio::awaitable<std::tuple<bool, std::optional<ExecutionResult>>> try_execution(const silkworm::Transaction& transaction);
 
     const BlockHeaderProvider& block_header_provider_;
     const AccountReader& account_reader_;


### PR DESCRIPTION
This PR brings the changes of PRs #593 and #594 from the `release/0.5` branch to the `main` branch and by doing so resolves #568 and #460.