### PR TITLE
Try reconnecting to SHiP again when read fails.

### DIFF
--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -52,7 +52,10 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
             SILK_CRIT << "SHiP initial read failed : " << ec.message();
             sys::error();
          }
-         abi = load_abi(eosio::json_token_stream{(char*)buff.data().data()});
+         auto end = buff.prepare(1);
+         ((char *)end.data())[0] = '\0';
+         buff.commit(1);
+         abi = load_abi(eosio::json_token_stream{(char *)buff.data().data()});
       }
 
       void send_request(const eosio::ship_protocol::request& req) {
@@ -250,7 +253,8 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
                stream->binary(true);
                stream->read_message_max(0x1ull << 36);
                connect_stream();
-               SILK_INFO << "Trying to sync again."; 
+               initial_read();
+               SILK_INFO << "Trying to sync again.";
                sync(true);
                return;
             }


### PR DESCRIPTION
Fix #579 #583 

Some behavior may subject to discussion:
1 Only retry if failed to read. that is, failed to send requests or failed to generate block will not trigger retry.
Logic here: majority of the recoverable (by reconnect) fails happen here and the reconnect logic is simple there. Supporting reconnect during other steps would be much more complex and the gain is marginal.

2 When reconnect to SHiP, start from 250s before canonical HEAD (if possible)
Logic here: 
a This approach is simple. No moving parts at all.
b It is well tested that the code can start from a certain early block.
c The block 250s before canonical HEAD must have been irreversible already.

(250s maybe too much, we can change that)