### PR TITLE
Allow reconnect to SHiP when disconnected

### DIFF
--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -410,6 +410,10 @@ void ship_receiver_plugin::set_program_options( appbase::options_description& cl
         "Override Antelope block id to start syncing from"  )
       ("ship-start-from-block-timestamp", boost::program_options::value<int64_t>(),
         "Timestamp for the provided ship-start-from-block-id, required if block-id provided"  )
+      ("ship-max-retry", boost::program_options::value<uint32_t>(),
+        "Max retry times before give up when trying to reconnect to SHiP endpoints"  )
+      ("ship-delay-second", boost::program_options::value<uint32_t>(),
+        "Deply in seconds between each retry when trying to reconnect to SHiP endpoints"  )
    ;
 }
 

--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -52,7 +52,10 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
             SILK_CRIT << "SHiP initial read failed : " << ec.message();
             sys::error();
          }
-         abi = load_abi(eosio::json_token_stream{(char*)buff.data().data()});
+         auto end = buff.prepare(1);
+         ((char *)end.data())[0] = '\0';
+         buff.commit(1);
+         abi = load_abi(eosio::json_token_stream{(char *)buff.data().data()});
       }
 
       void send_request(const eosio::ship_protocol::request& req) {
@@ -250,7 +253,8 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
                stream->binary(true);
                stream->read_message_max(0x1ull << 36);
                connect_stream();
-               SILK_INFO << "Trying to sync again."; 
+               initial_read();
+               SILK_INFO << "Trying to sync again.";
                sync(true);
                return;
             }

--- a/cmd/ship_receiver_plugin.cpp
+++ b/cmd/ship_receiver_plugin.cpp
@@ -341,7 +341,7 @@ class ship_receiver_plugin_impl : std::enable_shared_from_this<ship_receiver_plu
          auto start_from = utils::to_block_num(head_header->mix_hash.bytes) + 1;
          SILK_INFO << "Canonical header start from block: " << start_from;
 
-         if (last_lib > 0) {
+         if (last_lib > 0 && last_lib < start_from) {
             // None zeor last_lib means we are in the process of reconnection.
             start_from = last_lib;
          }


### PR DESCRIPTION
Draft for the reconnection. 

Current behavior: 

If disconnected. it will try reconnecting to the SHiP for a configurable maximum times with a configurable delay for each retry. A successful read of block will reset the reconnection timer.